### PR TITLE
ci: reduce renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,4 @@
 {
   "extends": ["config:base"],
-  "schedule": ["before 5am every weekday"],
-  "prConcurrentLimit": 3,
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["*"],
-      "rangeStrategy": "replace"
-    },
-    {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "prPriority": -1
-    },
-    {
-      "matchPackagePatterns": ["eslint", "stylelint", "prettier", "commitlint"],
-      "matchPackageNames": ["lint-staged", "husky"],
-      "groupName": "linter",
-      "schedule": ["before 6am on friday"]
-    },
-    {
-      "matchPackagePatterns": ["@types/"],
-      "matchPackageNames": [
-        "typescript",
-        "ts-node",
-        "tsconfig-paths-webpack-plugin"
-      ],
-      "groupName": "typescript",
-      "schedule": ["before 6am on monday"]
-    }
-  ]
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Since the `replace` methode only replaces the version if it it out of range we don't need all the oder options. There is no auto merge because there is never a bug-fix version replacement, no combining of package sin one branch because there is maybe just 1 version upgrade in 3 month => also no concurent branch limits etc.